### PR TITLE
fix bug plus enable configurable blacklist source

### DIFF
--- a/mobros/constants.py
+++ b/mobros/constants.py
@@ -56,3 +56,7 @@ class Commands(Enum):
     PUBLISH = "publish"
     RAISE = "raise"
     PING = "ping"
+
+MOBROS_CONFIG_PATH = "/etc/mobros/config"
+MOBROS_CONFIG_SECTION = "conflict-solving"
+MOBROS_CONFIG_BLACKLIST_KEY = "blacklistSource"

--- a/mobros/dependency_manager/conflict_solver.py
+++ b/mobros/dependency_manager/conflict_solver.py
@@ -3,8 +3,7 @@ import sys
 
 import mobros.utils.logger as logging
 from mobros.utils import apt_utils, version_utils
-
-
+from mobros.utils.utilitary import is_blacklisted_origin
 
 
 # def check_deps(name, version, ideb_name, ideb_version, visited=None):
@@ -144,6 +143,7 @@ def attempt_conflicts_solving(conflicts_list, dependency_bank, blacklist):
         conflicts_list (list): list of conflicts
         dependency_bank (dependency_bank): Dependency manager's dependency bank
     """
+
     mandatory_converger_version = None
 
     logging.userWarning("Trying to find a solution for the conflicts")
@@ -161,7 +161,7 @@ def attempt_conflicts_solving(conflicts_list, dependency_bank, blacklist):
 
         if mandatory_converger_version:
             pkg_origin = apt_utils.get_package_origin(conflict["name"])
-            if pkg_origin is not None and "mov.ai" not in pkg_origin:
+            if not is_blacklisted_origin(pkg_origin):
                 if (
                     len(possibilities.keys()) == 1
                     and mandatory_converger_version in possibilities

--- a/mobros/dependency_manager/dependency_manager.py
+++ b/mobros/dependency_manager/dependency_manager.py
@@ -776,6 +776,10 @@ class DependencyManager:
 
                 candidates = apt_utils.find_candidates_online_fullfilling_dependency(colision["name"], colision["dependency"]["name"], dep_version_rule)
                 self.render_tree()
+                if len(candidates) == 0:
+                    logging.error("Unable to solve.")
+                    sys.exit(1)
+
                 if self.conflict_solving:
                     rules = [version_utils.create_version_rule("version_eq", colision["version"], "Installed"),
                              version_utils.create_version_rule("version_eq", candidates[0], "mobros")

--- a/mobros/handler.py
+++ b/mobros/handler.py
@@ -3,6 +3,7 @@ import argparse
 import sys
 
 import mobros.utils.logger as logging
+from mobros.utils.utilitary import load_mobros_configuration
 from mobros.commands.ping.ping_executer import PingExecuter
 from mobros.commands.ros_build.build_executer import RosBuildExecuter
 from mobros.commands.ros_install_build_deps.install_deps_executer import (
@@ -55,7 +56,7 @@ def handle():
     h = ns.h
 
     sub = pre_parser.add_subparsers()
-
+    load_mobros_configuration()
     try:
         executer = executors[command]
         sub_parser = sub.add_parser(command, description=executer.get_description())

--- a/mobros/types/mobros_global_data.py
+++ b/mobros/types/mobros_global_data.py
@@ -6,6 +6,7 @@ class GlobalData:
 
     _instance = None
     _pkg_list = {}
+    _pkg_source_blacklist_patterns = []
 
     def __new__(cls):
         """Singleton lock of instance"""
@@ -16,9 +17,6 @@ class GlobalData:
 
     def set_user_package(self, package_name, version):
         """Set user package list
-
-        Returns:
-            dict: apt cache dict
         """
 
         self._pkg_list[package_name] = version
@@ -38,3 +36,18 @@ class GlobalData:
             dict: apt cache dict
         """
         return package_name in self._pkg_list
+
+    def set_conflict_solving_blacklist(self, blacklist_patterns):
+        """Set the blacklist patterns for mobros auto conflict solving
+
+        """
+
+        self._pkg_source_blacklist_patterns = blacklist_patterns
+
+    def get_conflict_solving_blacklist(self):
+        """Get the blacklist patterns for mobros auto conflict solving
+
+        Returns:
+            list: package source blacklist patterns
+        """
+        return self._pkg_source_blacklist_patterns

--- a/mobros/utils/apt_utils.py
+++ b/mobros/utils/apt_utils.py
@@ -420,7 +420,10 @@ def get_package_origin(deb_name):
     package = cache.get(deb_name)
     if package:
         if package.is_installed:
-            return package.installed.origins[0].site
+            dirty_pkg_source = package.versions.get(package.installed.version).uri
+            dirty_pkg_source = dirty_pkg_source.replace('https://', '')
+            clean_source = dirty_pkg_source.split("/pool")[0]
+            return clean_source
 
     return None
 

--- a/mobros/utils/utilitary.py
+++ b/mobros/utils/utilitary.py
@@ -11,7 +11,7 @@ import configparser
 from ruamel.yaml import YAML
 import mobros.utils.logger as logging
 from mobros.types.mobros_global_data import GlobalData
-
+from mobros.constants import MOBROS_CONFIG_PATH, MOBROS_CONFIG_SECTION, MOBROS_CONFIG_BLACKLIST_KEY
 
 def __process_shell_stdout_lines(command, envs=None, shell_mode=False):
     """Function that on the execution of a commandline command, yelds on each output"""
@@ -209,14 +209,15 @@ def parrallel_execute_function(function_to_execute, multiplexer_list):
 def load_mobros_configuration():
     """Function that loads the mobros configuration from the configuration file"""
 
-    conf_parser = configparser.ConfigParser()
-    conf_parser.read("/etc/mobros/config")
+    if path.exists(MOBROS_CONFIG_PATH):
+        conf_parser = configparser.ConfigParser()
+        conf_parser.read(MOBROS_CONFIG_PATH)
 
-    config_blacklist_src = conf_parser.get("conflict-solving","blacklistSource").split(",")
-    blacklist_patterns = []
-    blacklist_patterns.extend(config_blacklist_src)
+        config_blacklist_src = conf_parser.get(MOBROS_CONFIG_SECTION, MOBROS_CONFIG_BLACKLIST_KEY).split(",")
+        blacklist_patterns = []
+        blacklist_patterns.extend(config_blacklist_src)
 
-    GlobalData().set_conflict_solving_blacklist(blacklist_patterns)
+        GlobalData().set_conflict_solving_blacklist(blacklist_patterns)
 
 def is_blacklisted_origin(pkg_origin):
     """Function that checks if a package origin is blacklisted

--- a/tests/test_executers/mocks/mock_apt_cache.py
+++ b/tests/test_executers/mocks/mock_apt_cache.py
@@ -19,6 +19,9 @@ class MockAptPkg:
     dependencies = []
     version = ""
     origins = [MockOrigin()]
+    uri="artifacts/repository/test"
+    def get(self, elem):
+        return self
 
 class MockAptInstalledCache:
     installed = {}
@@ -31,7 +34,7 @@ class MockAptInstalledCache:
         self.installed.dependencies = []
         self.installed.dependencies.extend(pkg_list)
         self.installed.version = version
-        self.versions = [self.installed]
+        self.versions = self.installed
 
     def is_installed(self):
         return True

--- a/tests/test_utils/test_apt_utils.py
+++ b/tests/test_utils/test_apt_utils.py
@@ -142,9 +142,9 @@ class TestAptUtils(unittest.TestCase):
     def test_apt_install_package(self):
         apt_utils.install_package("banana","0.0.0", True)
         
-    @mock.patch("mobros.types.apt_cache_singleton.AptCache.__new__", return_value=MockAptCache(mock_apt_versions))
+    @mock.patch("mobros.types.apt_cache_singleton.AptCache.__new__", return_value=MockAptInstalledCache(PKG_NAME, PKG_VERSION, [INSTALLED_PKG_DEPENDENCIES_PY_1_0]))
     def test_cache_package_origin(self, mock_apt_cache_new):
-        apt_utils.get_package_origin("python2")
+        apt_utils.get_package_origin("python3")
     
     @mock.patch("mobros.types.apt_cache_singleton.AptCache.__new__", return_value=MockAptCache(mock_apt_versions))
     def test_get_package_available_versions(self, mock_apt_cache_new):

--- a/tests/test_utils/test_utilitary.py
+++ b/tests/test_utils/test_utilitary.py
@@ -5,7 +5,8 @@ from os.path import dirname, exists, realpath
 import mock
 
 from mobros.constants import TEST_RESOURCE_SHELL_SCRIPT
-from mobros.utils.utilitary import execute_bash_script, execute_shell_command
+from mobros.utils.utilitary import execute_bash_script, execute_shell_command, is_blacklisted_origin
+from mobros.types.mobros_global_data import GlobalData
 
 dir_path = dirname(realpath(__file__))
 relative_path_to_resources = dir_path + "/../resources/"
@@ -45,3 +46,13 @@ class TestUtilitary(unittest.TestCase):
             self.assertTrue(False)
         except Exception:
             pass
+
+    def test_is_blacklisted_origin(self):
+        
+        GlobalData().set_conflict_solving_blacklist(["*.mov.ai/repository/ppa-testing","*.mov.ai/repository/ppa-main"])
+        self.assertTrue(is_blacklisted_origin("artifacts.mov.ai/repository/ppa-testing"))
+        self.assertTrue(is_blacklisted_origin("artifacts.aws.mov.ai/repository/ppa-testing"))
+        self.assertTrue(is_blacklisted_origin("internet.mov.ai/repository/ppa-testing"))
+
+        self.assertFalse(is_blacklisted_origin("internet.moving.ai/repository/ppa-testing"))
+        self.assertFalse(is_blacklisted_origin("internet.moving.ai/repository/production"))


### PR DESCRIPTION
Have mobros read from a config file the blacklisted sources for conflict solving.
Fix bug on empty solutions not exiting.