### PR TITLE
DP-1855 : Review package.xml parsin for better robustness

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       args: ["--line-length=120", "-S"]
 
   - repo: https://github.com/pycqa/flake8   # static tests Python code
-    rev: 7.1.2
+    rev: 7.2.0
     hooks:
     - id: flake8
       args: ['--config', '.flake8']

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,11 +1,5 @@
 [MESSAGES CONTROL]
-disable=print-statement,
-        parameter-unpacking,
-        unpacking-in-except,
-        old-raise-syntax,
-        backtick,
-        no-self-use,
-        duplicate-code,
+disable=duplicate-code,
         invalid-name
 ignore=tests, node_modules, start.py, local_deploy.py
 ignore-patterns=.*_test.*?py,.*test_.*?py,.*test.*?py,.*pb2.*,.*yml, .*toml, .*txt, .*md, .*yaml, .*bash, .*json

--- a/mobros/commands/ros_install_build_deps/catkin_package.py
+++ b/mobros/commands/ros_install_build_deps/catkin_package.py
@@ -2,6 +2,7 @@
 
 import xml.etree.ElementTree as ET
 from os.path import isfile, join
+from typing import Optional
 
 import mobros.utils.logger as logging
 from mobros.constants import CATKIN_BLACKLIST_FILES
@@ -27,15 +28,24 @@ class CatkinPackage:
     """Class that represents a catkin package and its dependencies"""
 
     def __init__(self, package_path, workspace_pkg_list=None):
-
         if workspace_pkg_list is None:
             workspace_pkg_list = []
 
         self.build_dependencies = {}
+        self.package_name = ""
 
-        tree = ET.parse(package_path)
-        root = tree.getroot()
-        self.package_name = root.findall("name")[0].text
+        root = self._parse_package_xml(package_path)
+        if root is None:
+            return
+
+        if len(root) > 0:
+            all_names = root.findall("name")
+            if len(all_names) > 0:
+                self.package_name = all_names[0].text
+            else:
+                logging.warning(f"No name element found in package XML ({package_path})")
+        else:
+            logging.warning(f"Empty root element in package XML ({package_path})")
 
         self._find_dependencies("build_depend", self.build_dependencies, root, workspace_pkg_list)
         self._find_dependencies("depend", self.build_dependencies, root, workspace_pkg_list)
@@ -51,9 +61,17 @@ class CatkinPackage:
         Returns:
             str: Catkin package name
         """
-        tree = ET.parse(package_path)
-        root = tree.getroot()
-        return root.findall("name")[0].text
+        root = CatkinPackage._parse_package_xml(package_path)
+        if root is None:
+            return ""
+
+        if len(root) > 0:
+            all_names = root.findall("name")
+            if len(all_names) > 0:
+                return all_names[0].text or ""
+            else:
+                logging.warning(f"No name element found in package XML ({package_path})")
+        return ""
 
     def get_dependencies(self):
         """Getter function to retrieve the package dependencies. Both depend and build_depend elements.
@@ -136,3 +154,27 @@ class CatkinPackage:
                     "from": self.package_name,
                 }
             )
+
+    @staticmethod
+    def _parse_package_xml(package_path: str) -> Optional[ET.Element]:
+        """Parse package.xml file and return the root element
+
+        Args:
+            package_path: Path to the package.xml file
+
+        Returns:
+            Root XML element or None if parsing failed
+        """
+        try:
+            if not isfile(package_path):
+                logging.warning(f"Package file not found: {package_path}")
+                return None
+
+            tree = ET.parse(package_path)
+            return tree.getroot()
+        except ET.ParseError as e:
+            logging.error(f"Failed to parse package XML at {package_path}: {str(e)}")
+            return None
+        except Exception as e:
+            logging.error(f"Error processing package XML at {package_path}: {str(e)}")
+            return None

--- a/tests/resources/test_dependencies/invalid_xml/package.xml
+++ b/tests/resources/test_dependencies/invalid_xml/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+#################################################################
+#   GENERATED SOURCE CODE, DO NOT EDIT EXCEPT EXPERIMENTALLY    #
+#################################################################
+-->
+<ProjectSchemaDefinitions xmlns="clr-namespace:Microsoft.Build.Framework.XamlTypes;assembly=Microsoft.Build.Framework">
+  <Rule Name="Linkage-libzmq-uiextension" PageTemplate="tool" DisplayName="NuGet Dependencies" SwitchPrefix="/" Order="1">
+    <Rule.Categories>
+      <Category Name="libzmq" DisplayName="libzmq" />
+    </Rule.Categories>
+    <Rule.DataSource>
+      <DataSource Persistence="ProjectFile" ItemType="" />
+    </Rule.DataSource>
+    <EnumProperty Name="Linkage-libzmq" DisplayName="Linkage" Description="How NuGet libzmq will be linked into the output of this project" Category="libzmq">
+      <EnumValue Name="" DisplayName="Not linked" />
+      <EnumValue Name="dynamic" DisplayName="Dynamic (DLL)" />
+      <EnumValue Name="static" DisplayName="Static (LIB)" />
+      <EnumValue Name="ltcg" DisplayName="Static using link time compile generation (LTCG)" />
+    </EnumProperty>
+  </Rule>
+</ProjectSchemaDefinitions>

--- a/tests/test_executers/test_catkin_package_manager.py
+++ b/tests/test_executers/test_catkin_package_manager.py
@@ -14,9 +14,7 @@ def mock_translation(key):
 
 
 class TestCatkinPackageManager(unittest.TestCase):
-    @mock.patch(
-        "mobros.utils.utilitary.translate_package_name", side_effect=mock_translation
-    )
+    @mock.patch("mobros.utils.utilitary.translate_package_name", side_effect=mock_translation)
     def test_package_attributes(self, mock):
         TEST_RESOURCE_PATH_VALID = os.path.join(
             os.getcwd(),
@@ -49,16 +47,12 @@ class TestCatkinPackageManager(unittest.TestCase):
             package_a.get_dependencies()["ros-noetic-ompl"][0]["operator"],
             "version_lte",
         )
-        self.assertEqual(
-            package_a.get_dependencies()["ros-noetic-ompl"][0]["version"], "1.5.2-6"
-        )
+        self.assertEqual(package_a.get_dependencies()["ros-noetic-ompl"][0]["version"], "1.5.2-6")
         self.assertEqual(
             package_a.get_dependencies()["ros-noetic-ompl"][1]["operator"],
             "version_gte",
         )
-        self.assertEqual(
-            package_a.get_dependencies()["ros-noetic-ompl"][1]["version"], "0.0.1-23"
-        )
+        self.assertEqual(package_a.get_dependencies()["ros-noetic-ompl"][1]["version"], "0.0.1-23")
 
         self.assertEqual(package_c.get_name(), "package_c")
         self.assertEqual(
@@ -69,3 +63,25 @@ class TestCatkinPackageManager(unittest.TestCase):
             package_c.get_dependencies()["ros-noetic-movai-navigation"][0]["operator"],
             "",
         )
+
+    @mock.patch("mobros.utils.utilitary.translate_package_name", side_effect=mock_translation)
+    def test_invalid_package_xml(self, mock):
+        """Test behavior when an invalid package.xml is provided"""
+        TEST_RESOURCE_PATH_INVALID = os.path.join(
+            os.getcwd(),
+            "tests",
+            "resources",
+            "test_dependencies",
+            "invalid_xml",
+            "package.xml",
+        )
+
+        # Creating a CatkinPackage with invalid XML should not raise exceptions
+        invalid_package = CatkinPackage(TEST_RESOURCE_PATH_INVALID)
+
+        # Verify default/fallback values are used
+        self.assertEqual(invalid_package.get_name(), "")
+        self.assertEqual(invalid_package.get_dependencies(), {})
+
+        # Test the static extract_name method as well
+        self.assertEqual(CatkinPackage.extract_name(TEST_RESOURCE_PATH_INVALID), "")


### PR DESCRIPTION
- better error handling of issues seen on movai_openzen_sensor repository where some package.xml found in a repo might be invalid

Error:
![image](https://github.com/user-attachments/assets/46bf5f1d-6348-4deb-9923-38d9c51916cc)

Relates to: https://github.com/MOV-AI/movai_openzen_sensor/pull/13

Fix:
![image](https://github.com/user-attachments/assets/3be79753-b9fa-4007-957b-a659fec83b8f)


---

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
