### PR TITLE
DP-2044: use environment variable for ROS distribution in rosdep update command

### DIFF
--- a/mobros/commands/ros_install_build_deps/install_deps_executer.py
+++ b/mobros/commands/ros_install_build_deps/install_deps_executer.py
@@ -41,7 +41,7 @@ class InstallBuildDependsExecuter:
                 "rosdep",
                 "update",
                 "--include-eol-distros",
-                "--rosdistro=noetic",
+                "--rosdistro=" + os.getenv("ROS_DISTRO", "noetic"),
             ],
             stop_on_error=True,
             log_output=True,


### PR DESCRIPTION
This pull request introduces a small but important improvement to the `install_deps_executer.py` script. The change makes the ROS distribution configurable by using the `ROS_DISTRO` environment variable, allowing for greater flexibility when updating dependencies.

* Made the ROS distribution selection dynamic by reading from the `ROS_DISTRO` environment variable, defaulting to `"noetic"` if not set, in the `execute` method of `install_deps_executer.py`.